### PR TITLE
Fix issue with csv empty lines on windows

### DIFF
--- a/martin_binance/margin_wrapper.py
+++ b/martin_binance/margin_wrapper.py
@@ -694,7 +694,7 @@ async def save_to_csv() -> None:
     """
     cls = StrategyBase
     file_name = Path(LAST_STATE_PATH, f"{ms.ID_EXCHANGE}_{ms.SYMBOL}.csv")
-    with open(file_name, mode="a", buffering=1) as csvfile:
+    with open(file_name, mode="a", buffering=1, newline='') as csvfile:
         writer = csv.writer(csvfile)
         while cls.strategy:
             writer.writerow(await save_trade_queue.get())


### PR DESCRIPTION
Fix is to add `newline=''`

As said in [documentation](https://docs.python.org/3/library/functions.html#open):

`newline` determines how to parse newline characters from the stream. It can be None, '', '\n', '\r', and '\r\n'. It works as follows:
- When reading input from the stream, if newline is None, universal newlines mode is enabled. Lines in the input can end in '\n', '\r', or '\r\n', and these are translated into '\n' before being returned to the caller. If it is '', universal newlines mode is enabled, but line endings are returned to the caller untranslated. If it has any of the other legal values, input lines are only terminated by the given string, and the line ending is returned to the caller untranslated.

- When writing output to the stream, if newline is None, any '\n' characters written are translated to the system default line separator, [os.linesep](https://docs.python.org/3/library/os.html#os.linesep). If newline is '' or '\n', no translation takes place. If newline is any of the other legal values, any '\n' characters written are translated to the given string.